### PR TITLE
Allow runners to run untagged jobs by default, and remove default tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 *.tfstate
 *.tfstate.backup
 */terraform.tfvars
+*/.terraform
+
+# Secrets
+*.pem

--- a/module/templates/gitlab_runner_user_data.sh
+++ b/module/templates/gitlab_runner_user_data.sh
@@ -28,6 +28,7 @@ sudo gitlab-runner register --non-interactive \
                        --registration-token "${GITLAB_RUNNER_TOKEN}" \
                        --executor "docker" \
                        --tag-list "${GITLAB_RUNNER_TAGS}" \
+                       --run-untagged="true" \
                        --description "docker-runner" \
                        --docker-image "${GITLAB_RUNNER_DOCKER_IMAGE}"
 

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -61,7 +61,7 @@ variable "gitlab_runner_token" {
 variable "gitlab_runner_tags" {
   type        = string
   description = "Gitlab Runner tag list (comma separated)."
-  default     = "specific,docker"
+  default     = ""
 }
 
 variable "gitlab_runner_docker_image" {


### PR DESCRIPTION
See [the docs](https://docs.gitlab.com/runner/register/#one-line-registration-command) for more details.